### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: gradle
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build --no-daemon

--- a/src/main/java/com/example/demo/HelloController.java
+++ b/src/main/java/com/example/demo/HelloController.java
@@ -1,0 +1,14 @@
+package com.example.demo;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/hello")
+    public Mono<String> hello() {
+        return Mono.just("Hello World!");
+    }
+}

--- a/src/test/java/com/example/demo/HelloControllerTests.java
+++ b/src/test/java/com/example/demo/HelloControllerTests.java
@@ -1,0 +1,24 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+class HelloControllerTests {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void helloEndpointReturnsHelloWorld() {
+        webTestClient.get()
+                .uri("/hello")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class).isEqualTo("Hello World!");
+    }
+}


### PR DESCRIPTION
## Summary
- implement a non-blocking REST controller returning "Hello World!"
- test controller using `WebTestClient`
- add Gradle build workflow for CI

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_683fdbd32ef883208a95da1e957522d9