### PR TITLE
Secure Hello endpoint with JWT auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,16 @@ repositories {
 	mavenCentral()
 }
 
-dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.projectreactor:reactor-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
+    dependencies {
+        implementation 'org.springframework.boot:spring-boot-starter-actuator'
+        implementation 'org.springframework.boot:spring-boot-starter-webflux'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testImplementation 'io.projectreactor:reactor-test'
+        testImplementation 'org.springframework.security:spring-security-test'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    }
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.example.demo.config;
+
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Bean
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        http
+            .authorizeExchange(exchanges -> exchanges
+                .pathMatchers("/hello").hasAuthority("SCOPE_demo.read")
+                .anyExchange().permitAll()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+        return http.build();
+    }
+
+    @Bean
+    ReactiveJwtDecoder jwtDecoder() {
+        SecretKeySpec key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+        return NimbusReactiveJwtDecoder.withSecretKey(key).macAlgorithm(org.springframework.security.oauth2.jose.jws.MacAlgorithm.HS256).build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=demo
+jwt.secret=secret-key-for-tests

--- a/src/test/java/com/example/demo/HelloControllerTests.java
+++ b/src/test/java/com/example/demo/HelloControllerTests.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -14,8 +15,17 @@ class HelloControllerTests {
     private WebTestClient webTestClient;
 
     @Test
-    void helloEndpointReturnsHelloWorld() {
+    void helloEndpointRequiresAuthentication() {
         webTestClient.get()
+                .uri("/hello")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    void helloEndpointReturnsHelloWorldWhenAuthenticated() {
+        webTestClient.mutateWith(SecurityMockServerConfigurers.mockJwt().authorities(() -> "SCOPE_demo.read"))
+                .get()
                 .uri("/hello")
                 .exchange()
                 .expectStatus().isOk()


### PR DESCRIPTION
## Summary
- require a JWT token with `demo.read` scope for `/hello`
- configure WebFlux resource server using HS256 secret
- update tests for new security setup
- add Spring Security dependencies

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6840d69b21b083208b08846c5de82ecc