### PR TITLE
Configure resource server via issuer URI

### DIFF
--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -1,20 +1,13 @@
 package com.example.demo.config;
 
-import javax.crypto.spec.SecretKeySpec;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
-import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
-import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 
 @Configuration
 public class SecurityConfig {
-
-    @Value("${jwt.secret}")
-    private String secret;
 
     @Bean
     SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
@@ -25,11 +18,5 @@ public class SecurityConfig {
             )
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
         return http.build();
-    }
-
-    @Bean
-    ReactiveJwtDecoder jwtDecoder() {
-        SecretKeySpec key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
-        return NimbusReactiveJwtDecoder.withSecretKey(key).macAlgorithm(org.springframework.security.oauth2.jose.jws.MacAlgorithm.HS256).build();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=demo
-jwt.secret=secret-key-for-tests
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://login.microsoftonline.com/{tenant-id}/v2.0

--- a/src/test/java/com/example/demo/HelloControllerTests.java
+++ b/src/test/java/com/example/demo/HelloControllerTests.java
@@ -24,7 +24,10 @@ class HelloControllerTests {
 
     @Test
     void helloEndpointReturnsHelloWorldWhenAuthenticated() {
-        webTestClient.mutateWith(SecurityMockServerConfigurers.mockJwt().authorities(() -> "SCOPE_demo.read"))
+        webTestClient.mutateWith(
+                SecurityMockServerConfigurers.mockJwt()
+                        .jwt(jwt -> jwt.claim("iss", "https://login.microsoftonline.com/{tenant-id}/v2.0"))
+                        .authorities(() -> "SCOPE_demo.read"))
                 .get()
                 .uri("/hello")
                 .exchange()


### PR DESCRIPTION
## Summary
- use `spring.security.oauth2.resourceserver.jwt.issuer-uri`
- drop secret-based JWT decoder
- update tests with issuer claim

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6841055bb5d08320b8499e833939446b